### PR TITLE
ホーム画面に登録商品一覧を表示

### DIFF
--- a/app/api/metadata/route.ts
+++ b/app/api/metadata/route.ts
@@ -1,0 +1,69 @@
+// POST 交換用アグリゲートトランザクションの署名とアナウンス
+
+import { NextResponse } from 'next/server';
+import { Account, AccountMetadataTransaction, AggregateTransaction, Deadline, KeyGenerator, TransactionStatus, UInt64 } from 'symbol-sdk';
+import { setupBlockChain } from '../../domain/utils/setupBlockChain';
+import { firstValueFrom } from 'rxjs';
+import { fetchTransactionStatus } from '../../domain/utils/fetches/fetchTransactionStatus';
+
+export const POST = async (req: Request, res: NextResponse<string | null>) => {
+  try {
+    if (req.method !== 'POST')
+      return NextResponse.json({ message: 'Bad Request' }, { status: 405 });
+
+    const { privateKey }: { privateKey: string} = await req.json();
+
+    const momijiBlockChain = await setupBlockChain('momiji');
+    const target = Account.createFromPrivateKey(privateKey, momijiBlockChain.networkType);
+
+    const momijiAdminPrivateKey = process.env.PRIVATE_KEY;
+    const momijiAdminAccount = Account.createFromPrivateKey(
+      momijiAdminPrivateKey,
+      momijiBlockChain.networkType,
+    );
+    const key = process.env.NEXT_PUBLIC_APP_NAME;
+    const value = "momiji";
+
+    const uint64key = KeyGenerator.generateUInt64Key(key);
+    const accountMetaDataTransaction: AccountMetadataTransaction = AccountMetadataTransaction.create(
+      Deadline.create(momijiBlockChain.epochAdjustment),
+      target.address,
+      uint64key,
+      value.length,
+      Uint8Array.from(Buffer.from(value)),
+      momijiBlockChain.networkType,
+    );
+
+    const aggregateTransaction = AggregateTransaction.createComplete(
+        Deadline.create(momijiBlockChain.epochAdjustment),
+        [
+          accountMetaDataTransaction.toAggregate(momijiAdminAccount.publicAccount),
+        ],
+        momijiBlockChain.networkType,
+        [],
+    ).setMaxFeeForAggregate(100, 2);;
+
+    const signedTransaction = target.signTransactionWithCosignatories(
+        aggregateTransaction,
+        [momijiAdminAccount],
+        momijiBlockChain.generationHash,
+    );
+
+    await firstValueFrom(momijiBlockChain.txRepo.announce(signedTransaction));
+    const signedTransactionHash = signedTransaction.hash
+
+    console.log(signedTransactionHash);
+
+    const result: TransactionStatus = await fetchTransactionStatus(
+      momijiBlockChain,
+      signedTransactionHash,
+      target.address,
+    );
+
+    console.log(result);
+
+    return NextResponse.json({ data: result }, { status: 200 });
+  } catch (err: any) {
+    return NextResponse.json({ message: err.message }, { status: 500 });
+  }
+};

--- a/app/domain/useCases/fetches/fetchAllProductinfo.ts
+++ b/app/domain/useCases/fetches/fetchAllProductinfo.ts
@@ -1,0 +1,73 @@
+import { AccountInfo, Address, KeyGenerator, Metadata, MetadataType, MosaicInfo, Page } from 'symbol-sdk';
+import { ProductInfo } from '../../entities/productInfo/productInfo';
+import { setupBlockChain } from '../../utils/setupBlockChain';
+import { firstValueFrom } from 'rxjs';
+
+export const fetchAllProductinfo = async (
+  address?: Address,
+): Promise<ProductInfo[]> => {
+  const momijiBlockChain = await setupBlockChain('momiji');
+  const momijiKey = KeyGenerator.generateUInt64Key(process.env.NEXT_PUBLIC_APP_NAME).toHex();
+  const key = 'productInfo';
+
+  // メタデータに設定された情報を取得
+  const metadataEntries :Page<Metadata> = await firstValueFrom(
+    momijiBlockChain.metaRepo.search({
+      metadataType: MetadataType.Account,
+      scopedMetadataKey: momijiKey,
+      pageNumber: 1,
+      pageSize: 1000
+  }),
+  ) as any;
+
+  const followDict = [];
+  for (let index = 0; index < metadataEntries.data.length; index++) {
+    followDict[index] = {
+        "address": metadataEntries.data[index].metadataEntry.targetAddress.plain(),
+    }
+  }
+
+
+  let productInfoList: ProductInfo[] = [];
+
+  for(let i = 0; i < followDict.length; i++) {
+
+    // アカウントリストからモザイクを取得
+    const mosaics :Page<MosaicInfo> = await firstValueFrom(
+      momijiBlockChain.mosaicRepo.search({
+        ownerAddress: Address.createFromRawAddress(followDict[i].address),
+      }),
+    ) as any;
+
+    for (const mosaic of mosaics.data) {
+      const mosaicId = mosaic.id;
+      const uint64keyToHex = KeyGenerator.generateUInt64Key(key).toHex();
+      const res = await firstValueFrom(
+        momijiBlockChain.metaRepo.search({
+          metadataType: MetadataType.Mosaic,
+          scopedMetadataKey: uint64keyToHex,
+          targetId: mosaicId,
+        }),
+      ) as any;
+
+      if (!res.data || !res.data[0] || !res.data[0].metadataEntry) {
+        continue; // 条件を満たさない場合は次のループへ
+      }
+
+      const value = res.data[0].metadataEntry.value;
+
+      let productInfo:ProductInfo
+
+      try {
+        productInfo = JSON.parse(value) as ProductInfo;
+        productInfoList.push(productInfo); // 条件を満たす値をリストに追加
+      } catch (error) {
+        console.error(`Error parsing product info for mosaic ${mosaicId.toHex()}: ${error}`); // オプション: エラーをログに記録
+        continue; // JSONのパースに失敗した場合は次のモザイクへ進む
+      }
+    }
+   }
+
+  return productInfoList;
+};
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,93 @@
 'use client';
+import React, { useEffect, useState } from 'react';
 import FlameComponent from './components/Flame';
+import useSetupBlockChain from './hooks/useSetupBlockChain';
+import { ProductInfo } from './domain/entities/productInfo/productInfo';
+import { fetchAllProductinfo } from './domain/useCases/fetches/fetchAllProductinfo';
+import { Backdrop, Box, Card, CardContent, Chip, Grid, Typography } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import AlertsSnackbar from './components/AlertsSnackbar';
+import Loading from './components/Loading';
 
 const Home = () => {
+  const router = useRouter();
+  const { momijiBlockChain } = useSetupBlockChain();
+  const [progress, setProgress] = useState<boolean>(true); //ローディングの設定
+  const [progressValue, setProgressValue] = useState<number>(100); //ローディングの設定
+  const [openSnackbar, setOpenSnackbar] = useState<boolean>(false); //AlertsSnackbarの設定
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'error' | 'success'>('error'); //AlertsSnackbarの設定
+  const [snackbarMessage, setSnackbarMessage] = useState<string>(''); //AlertsSnackbarの設定
+  const [productList, setProductList] = useState<ProductInfo[] | null>(null); //productList
+
+  useEffect(() => {
+    if (momijiBlockChain) {
+
+      const func = async () => {
+        const productInfoList = await fetchAllProductinfo();
+        setProductList(productInfoList)
+        setProgress(false)
+      };
+      func();
+    }
+  }
+  , [momijiBlockChain]);
+
   return (
     <>
-      <FlameComponent>this is the home page</FlameComponent>
+      <FlameComponent children={''}></FlameComponent>
+      <AlertsSnackbar
+        openSnackbar={openSnackbar}
+        setOpenSnackbar={setOpenSnackbar}
+        vertical={'bottom'}
+        snackbarSeverity={snackbarSeverity}
+        snackbarMessage={snackbarMessage}
+      />
+      {progress ? (
+        <Backdrop open={progress}>
+          <Loading value={progressValue} />
+        </Backdrop>
+      ) : (
+        <Box component="section" sx={{ p: 2 }}>
+          <Grid container spacing={4}>
+            {productList?.map((product, index) => (
+              <Grid item key={index}>
+                <Card onClick={() => router.push(`/product/detail?mosaicId=${product.mosaicId}`)} style={{ cursor: 'pointer' }}>
+                  <CardContent>
+                    <Typography gutterBottom variant="h5" component="div">
+                      {product.productName}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      販売者: {product.sellerName}
+                    </Typography>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      style={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 1, // 表示する行数
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      説明: {product.description}
+                    </Typography>
+
+                    <Typography variant="body2" color="text.secondary">
+                      価格: {product.price}xym
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+                      {product.category.map((category, index) => (
+                        <Chip key={index} label={category} variant="outlined" />
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+          </Box>
+      )}
     </>
   );
 };

--- a/sample.env
+++ b/sample.env
@@ -1,3 +1,4 @@
+NEXT_PUBLIC_APP_NAME= bridge_pay
 PRIVATE_KEY=xxxxxxxxxxx
 NEXT_PUBLIC_ADMIN_ADDRESS=xxxxxxxxxxx
 NEXT_PUBLIC_ADMIN_PUBLIC_KEY=xxxxxxxxxxx


### PR DESCRIPTION
メタデータを参照して商品一覧を取得・表示する機能を追加しました。」

## 手順

環境変数（.env）へ「NEXT_PUBLIC_APP_NAME= bridge_pay」を追加する。
メタデータ登録処理は、商品を登録する際の初回momijiアカウント生成時に行う。（なので現状既存のアドレスには適用されていない）